### PR TITLE
Add no_null_override mergo data modifier optional flag

### DIFF
--- a/internal/provider/mergo_function.go
+++ b/internal/provider/mergo_function.go
@@ -55,7 +55,7 @@ func (r MergoFunction) Run(ctx context.Context, req function.RunRequest, resp *f
 	objs := make([]types.Dynamic, 0)
 	opts := make([]func(*mergo.Config), 0)
 	with_override := true
-	without_null_override := false
+	no_null_override := false
 
 	for i, arg := range args {
 		if arg.IsNull() {
@@ -68,8 +68,8 @@ func (r MergoFunction) Run(ctx context.Context, req function.RunRequest, resp *f
 			switch option := arg.String(); option {
 			case `"no_override"`:
 				with_override = false
-			case `"without_null_override"`:
-				without_null_override = true
+			case `"no_null_override"`:
+				no_null_override = true
 			case `"override"`, `"replace"`:
 				with_override = true
 			case `"append"`, `"append_lists"`:
@@ -92,7 +92,7 @@ func (r MergoFunction) Run(ctx context.Context, req function.RunRequest, resp *f
 		opts = append(opts, mergo.WithOverride)
 	}
 
-	if without_null_override {
+	if no_null_override {
 		opts = append(opts, mergo.WithTransformers(noNullOverrideTransformer{}))
 	}
 

--- a/internal/provider/mergo_function.go
+++ b/internal/provider/mergo_function.go
@@ -5,6 +5,7 @@ package provider
 
 import (
 	"context"
+	"reflect"
 
 	"dario.cat/mergo"
 	"github.com/hashicorp/terraform-plugin-framework/function"
@@ -54,6 +55,7 @@ func (r MergoFunction) Run(ctx context.Context, req function.RunRequest, resp *f
 	objs := make([]types.Dynamic, 0)
 	opts := make([]func(*mergo.Config), 0)
 	with_override := true
+	without_null_override := false
 
 	for i, arg := range args {
 		if arg.IsNull() {
@@ -66,6 +68,8 @@ func (r MergoFunction) Run(ctx context.Context, req function.RunRequest, resp *f
 			switch option := arg.String(); option {
 			case `"no_override"`:
 				with_override = false
+			case `"without_null_override"`:
+				without_null_override = true
 			case `"override"`, `"replace"`:
 				with_override = true
 			case `"append"`, `"append_lists"`:
@@ -88,6 +92,10 @@ func (r MergoFunction) Run(ctx context.Context, req function.RunRequest, resp *f
 		opts = append(opts, mergo.WithOverride)
 	}
 
+	if without_null_override {
+		opts = append(opts, mergo.WithTransformers(noNullOverrideTransformer{}))
+	}
+
 	merged, diags := helpers.Mergo(ctx, objs, opts...)
 	if diags.HasError() {
 		resp.Error = function.FuncErrorFromDiags(ctx, diags)
@@ -95,4 +103,45 @@ func (r MergoFunction) Run(ctx context.Context, req function.RunRequest, resp *f
 	}
 
 	resp.Error = function.ConcatFuncErrors(resp.Result.Set(ctx, &merged))
+}
+
+type noNullOverrideTransformer struct {
+}
+
+func (t noNullOverrideTransformer) Transformer(typ reflect.Type) func(dst, src reflect.Value) error {
+	if typ.Kind() == reflect.Map {
+		return func(dst, src reflect.Value) error {
+			deepMergeMaps(dst, src)
+			return nil
+		}
+	}
+	return nil
+}
+
+func deepMergeMaps(dst, src reflect.Value) reflect.Value {
+	for _, key := range src.MapKeys() {
+		srcElem := src.MapIndex(key)
+		dstElem := dst.MapIndex(key)
+
+		// Unwrap the interfaces of srcElem and dstElem
+		if srcElem.Kind() == reflect.Interface {
+			srcElem = srcElem.Elem()
+		}
+
+		if dstElem.Kind() == reflect.Interface {
+			dstElem = dstElem.Elem()
+		}
+
+		if srcElem.Kind() == reflect.Map && dstElem.Kind() == reflect.Map {
+			// recursive call
+			newValue := deepMergeMaps(dstElem, srcElem)
+			dst.SetMapIndex(key, newValue)
+		} else {
+			if !srcElem.IsValid() { // skip override of nil values
+				continue
+			}
+			dst.SetMapIndex(key, srcElem)
+		}
+	}
+	return dst
 }

--- a/internal/provider/mergo_function_test.go
+++ b/internal/provider/mergo_function_test.go
@@ -320,3 +320,344 @@ func TestMergoFunction_Null(t *testing.T) {
 		},
 	})
 }
+
+func TestMergoFunction_NoOverrideWithNull(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.8.0"))),
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+				locals {
+					map1 = {
+						a = "foo"
+						b = "bar"
+					}
+					map2 = {
+						b = "bam"
+					}
+				}
+				output "test" {
+					value = provider::deepmerge::mergo(local.map1, local.map2, "without_null_override")
+				}
+				`,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownOutputValue("test",
+						knownvalue.MapExact(map[string]knownvalue.Check{
+							"a": knownvalue.StringExact("foo"),
+							"b": knownvalue.StringExact("bam"),
+						}),
+					),
+				},
+			},
+			{
+				Config: `
+				locals {
+					map1 = {
+						a = "foo"
+						b = "bar"
+					}
+					map2 = {
+					}
+				}
+				output "test" {
+					value = provider::deepmerge::mergo(local.map1, local.map2, "without_null_override")
+				}
+				`,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownOutputValue("test",
+						knownvalue.MapExact(map[string]knownvalue.Check{
+							"a": knownvalue.StringExact("foo"),
+							"b": knownvalue.StringExact("bar"),
+						}),
+					),
+				},
+			},
+			{
+				Config: `
+				locals {
+					map1 = {
+						x1 = {
+							y1 = false
+							y2 = 1
+						}
+					}
+					map2 = {
+						x1 = {
+							y2 = 1
+							y3 = [4, 5, 6]
+						}
+						x2 = {
+							y4 = {
+								a = "hello"
+								b = "world"
+							}
+						}
+					}
+					map3 = {
+						x1 = {
+							y1 = true
+							y3 = [1, 2, 3]
+						}
+						x2 = {
+							y4 = {
+								b = "mergo"
+								c = ["a", 2, ["b"]]
+							}
+						}
+					}
+				}
+				output "test" {
+					value = provider::deepmerge::mergo(local.map1, local.map2, local.map3, "without_null_override")
+				}
+				`,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownOutputValue("test",
+						knownvalue.MapExact(map[string]knownvalue.Check{
+							"x1": knownvalue.MapExact(map[string]knownvalue.Check{
+								"y1": knownvalue.Bool(true),
+								"y2": knownvalue.Int64Exact(1),
+								"y3": knownvalue.ListExact([]knownvalue.Check{
+									knownvalue.Int64Exact(1),
+									knownvalue.Int64Exact(2),
+									knownvalue.Int64Exact(3),
+								}),
+							}),
+							"x2": knownvalue.MapExact(map[string]knownvalue.Check{
+								"y4": knownvalue.MapExact(map[string]knownvalue.Check{
+									"a": knownvalue.StringExact("hello"),
+									"b": knownvalue.StringExact("mergo"),
+									"c": knownvalue.ListExact([]knownvalue.Check{
+										knownvalue.StringExact("a"),
+										knownvalue.Int64Exact(2),
+										knownvalue.ListExact([]knownvalue.Check{
+											knownvalue.StringExact("b"),
+										}),
+									}),
+								}),
+							}),
+						}),
+					),
+				},
+			},
+			{
+				Config: `
+				locals {
+					map1 = {
+						a = "foo"
+						b = "bar"
+					}
+					map2 = {
+						a = null
+						b = "bam"
+					}
+				}
+				output "test" {
+					value = provider::deepmerge::mergo(local.map1, local.map2, "without_null_override")
+				}
+				`,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownOutputValue("test",
+						knownvalue.MapExact(map[string]knownvalue.Check{
+							"a": knownvalue.StringExact("foo"),
+							"b": knownvalue.StringExact("bam"),
+						}),
+					),
+				},
+			},
+			{
+				Config: `
+				locals {
+					map1 = {
+						a = "foo"
+						b = "bar"
+					}
+					map2 = {
+						a = null
+						b = null
+					}
+				}
+				output "test" {
+					value = provider::deepmerge::mergo(local.map1, local.map2, "without_null_override")
+				}
+				`,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownOutputValue("test",
+						knownvalue.MapExact(map[string]knownvalue.Check{
+							"a": knownvalue.StringExact("foo"),
+							"b": knownvalue.StringExact("bar"),
+						}),
+					),
+				},
+			},
+			{
+				Config: `
+				locals {
+					map1 = {
+						x1 = {
+							y1 = false
+							y2 = 1
+						}
+					}
+					map2 = {
+						x1 = {
+							y2 = 1
+							y3 = [4, 5, 6]
+						}
+						x2 = {
+							y4 = {
+								a = "hello"
+								b = "world"
+							}
+						}
+					}
+					map3 = {
+						x1 = {
+							y1 = true
+							y3 = [1, 2, 3]
+						}
+						x2 = {
+							y4 = {
+								b = "mergo"
+								c = ["a", 2, ["b"]]
+							}
+						}
+					}
+				}
+				output "test" {
+					value = provider::deepmerge::mergo(local.map1, local.map2, local.map3, "without_null_override")
+				}
+				`,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownOutputValue("test",
+						knownvalue.MapExact(map[string]knownvalue.Check{
+							"x1": knownvalue.MapExact(map[string]knownvalue.Check{
+								"y1": knownvalue.Bool(true),
+								"y2": knownvalue.Int64Exact(1),
+								"y3": knownvalue.ListExact([]knownvalue.Check{
+									knownvalue.Int64Exact(1),
+									knownvalue.Int64Exact(2),
+									knownvalue.Int64Exact(3),
+								}),
+							}),
+							"x2": knownvalue.MapExact(map[string]knownvalue.Check{
+								"y4": knownvalue.MapExact(map[string]knownvalue.Check{
+									"a": knownvalue.StringExact("hello"),
+									"b": knownvalue.StringExact("mergo"),
+									"c": knownvalue.ListExact([]knownvalue.Check{
+										knownvalue.StringExact("a"),
+										knownvalue.Int64Exact(2),
+										knownvalue.ListExact([]knownvalue.Check{
+											knownvalue.StringExact("b"),
+										}),
+									}),
+								}),
+							}),
+						}),
+					),
+				},
+			},
+			{
+				Config: `
+				locals {
+					map1 = {
+						x1 = {
+							y2 = {
+								z1 = 1
+								z2 = 2
+							}
+						}
+						x2 = {
+							s1 = "hello"
+							s2 = "world"
+							s3 = null
+						}
+						x3 = {
+							t1 = "foo"
+						}
+					}
+					map2 = {
+						x1 = {
+							y2 = {
+								z3 = 3
+								z2 = null
+							}
+							y2 = "bar"
+						}
+						x3 = {
+							t1 = null
+						}
+					}
+					map3 = {
+						x1 = {
+							y2 = null
+						}
+					}
+					map4 = {
+						x1 = {
+							y1 = 4
+						}
+					}
+					map5 = {
+						x1 = {
+							y2 = {
+								z1 = {
+									n1 = 1
+									n2 = {
+										m1 = 1
+									}
+								}
+								z2 = null
+								z3 = null
+								z4 = 4
+							}
+						}
+						x2 = {
+							s2 = "mergo"
+							s4 = "today"
+						}
+						x3 = {
+							t2 = "foz"
+						}
+					}
+				}
+				output "test" {
+					value = provider::deepmerge::mergo(local.map1, local.map2, local.map3, local.map4, local.map5, "without_null_override")
+				}
+				`,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownOutputValue("test",
+						knownvalue.MapExact(map[string]knownvalue.Check{
+							"x1": knownvalue.MapExact(map[string]knownvalue.Check{
+								"y1": knownvalue.Int64Exact(4),
+								"y2": knownvalue.MapExact(map[string]knownvalue.Check{
+									"z1": knownvalue.MapExact(map[string]knownvalue.Check{
+										"n1": knownvalue.Int64Exact(1),
+										"n2": knownvalue.MapExact(map[string]knownvalue.Check{
+											"m1": knownvalue.Int64Exact(1),
+										}),
+									}),
+									"z2": knownvalue.Null(),
+									"z3": knownvalue.Null(),
+									"z4": knownvalue.Int64Exact(4),
+								}),
+							}),
+							"x2": knownvalue.MapExact(map[string]knownvalue.Check{
+								"s1": knownvalue.StringExact("hello"),
+								"s2": knownvalue.StringExact("mergo"),
+								"s3": knownvalue.Null(),
+								"s4": knownvalue.StringExact("today"),
+							}),
+							"x3": knownvalue.MapExact(map[string]knownvalue.Check{
+								"t1": knownvalue.StringExact("foo"),
+								"t2": knownvalue.StringExact("foz"),
+							}),
+						}),
+					),
+				},
+			},
+		},
+	})
+}

--- a/internal/provider/mergo_function_test.go
+++ b/internal/provider/mergo_function_test.go
@@ -340,7 +340,7 @@ func TestMergoFunction_NoOverrideWithNull(t *testing.T) {
 					}
 				}
 				output "test" {
-					value = provider::deepmerge::mergo(local.map1, local.map2, "without_null_override")
+					value = provider::deepmerge::mergo(local.map1, local.map2, "no_null_override")
 				}
 				`,
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -363,7 +363,7 @@ func TestMergoFunction_NoOverrideWithNull(t *testing.T) {
 					}
 				}
 				output "test" {
-					value = provider::deepmerge::mergo(local.map1, local.map2, "without_null_override")
+					value = provider::deepmerge::mergo(local.map1, local.map2, "no_null_override")
 				}
 				`,
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -410,7 +410,7 @@ func TestMergoFunction_NoOverrideWithNull(t *testing.T) {
 					}
 				}
 				output "test" {
-					value = provider::deepmerge::mergo(local.map1, local.map2, local.map3, "without_null_override")
+					value = provider::deepmerge::mergo(local.map1, local.map2, local.map3, "no_null_override")
 				}
 				`,
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -455,7 +455,7 @@ func TestMergoFunction_NoOverrideWithNull(t *testing.T) {
 					}
 				}
 				output "test" {
-					value = provider::deepmerge::mergo(local.map1, local.map2, "without_null_override")
+					value = provider::deepmerge::mergo(local.map1, local.map2, "no_null_override")
 				}
 				`,
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -480,7 +480,7 @@ func TestMergoFunction_NoOverrideWithNull(t *testing.T) {
 					}
 				}
 				output "test" {
-					value = provider::deepmerge::mergo(local.map1, local.map2, "without_null_override")
+					value = provider::deepmerge::mergo(local.map1, local.map2, "no_null_override")
 				}
 				`,
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -527,7 +527,7 @@ func TestMergoFunction_NoOverrideWithNull(t *testing.T) {
 					}
 				}
 				output "test" {
-					value = provider::deepmerge::mergo(local.map1, local.map2, local.map3, "without_null_override")
+					value = provider::deepmerge::mergo(local.map1, local.map2, local.map3, "no_null_override")
 				}
 				`,
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -581,8 +581,8 @@ func TestMergoFunction_NoOverrideWithNull(t *testing.T) {
 					map2 = {
 						x1 = {
 							y2 = {
-								z3 = 3
 								z2 = null
+								z3 = 3
 							}
 							y2 = "bar"
 						}
@@ -624,7 +624,7 @@ func TestMergoFunction_NoOverrideWithNull(t *testing.T) {
 					}
 				}
 				output "test" {
-					value = provider::deepmerge::mergo(local.map1, local.map2, local.map3, local.map4, local.map5, "without_null_override")
+					value = provider::deepmerge::mergo(local.map1, local.map2, local.map3, local.map4, local.map5, "no_null_override")
 				}
 				`,
 				ConfigStateChecks: []statecheck.StateCheck{


### PR DESCRIPTION
Accommodates the use-case raised in #39 by leveraging mergo's ["Transformers"](https://github.com/darccio/mergo?tab=readme-ov-file#transformers).

The merge logic, when the `"without_null_override"` parameter is set, will not merge null values over non-null values.

Example usage:

```
resource "terraform_data" "merged" {
  input = provider::deepmerge::mergo("without_null_override", m1, m2, m3)
}
```
