### PR TITLE
fix: OpenTofu crash with unknown value

### DIFF
--- a/internal/helpers/encode.go
+++ b/internal/helpers/encode.go
@@ -13,7 +13,9 @@ import (
 )
 
 func EncodeValue(v attr.Value) (any, error) {
-	if v.IsNull() {
+	// Avoid nil pointer deref with broken OpenTofu custom function
+	// implementation that passes unknown values as zero values.
+	if v == nil || v.IsNull() {
 		return nil, nil
 	}
 


### PR DESCRIPTION
* OpenTofu (and only OpenTofu) passes zero values in place of unknowns
  when calling custom functions, and ignores the `AllowUnknownValues`
  parameter configuration.
  Besides being incorrect, misleading and resulting in unstable plans,
  this can also result in rogue nil pointers being embedded in custom
  function inputs and thus unexpected panics in the provider code.
  Amusingly the standard `v.IsNull()` function itself was triggering a
  nil-pointer deref 😭.
  We work around it by explicitly checking that all values aren't nil,
  but this is a temporary fix until the underlying issue can be resolved
  upstream in OpenTofu itself.

Refs: #48