### PR TITLE
feat: union mode to treat lists as sets

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,9 +7,6 @@ on:
   pull_request:
     paths-ignore:
       - "README.md"
-  push:
-    paths-ignore:
-      - "README.md"
 
 # Testing only needs permissions to read the repository contents.
 permissions:

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ A distinctive feature of `mergo` is its use of string arguments to control merge
 | `"no_override"`                      | Earlier values are preserved               | Setting immutable defaults            |
 | `"no_null_override"`                 | Null values don't replace existing values  | Optional configuration fields         |
 | `"append"` / `"append_lists"`        | Lists are concatenated instead of replaced | Accumulating features, rules, or tags |
+| `"union"` / `"union_lists"`          | Lists are merged as sets (unique elements) | Deduplicating tags, IPs, or identifiers |
 
 ### Examples by Mode
 
@@ -117,6 +118,34 @@ locals {
   #   firewall = {
   #     allowed_ports = [22, 80, 443, 8080, 9090]
   #     denied_ips    = ["192.168.1.100", "192.168.1.101", "192.168.1.102"]
+  #   }
+  # }
+}
+```
+
+#### Union Lists Mode
+
+```hcl
+locals {
+  base_tags = {
+    security = {
+      allowed_ports = [22, 80, 443]
+      tags = ["security", "prod", "critical"]
+    }
+  }
+
+  additional_tags = {
+    security = {
+      allowed_ports = [8080, 80, 9090]
+      tags = ["monitoring", "prod", "audit"]
+    }
+  }
+
+  result = provider::deepmerge::mergo(local.base_tags, local.additional_tags, "union_lists")
+  # Result: {
+  #   security = {
+  #     allowed_ports = [22, 80, 443, 8080, 9090]  # Unique elements only
+  #     tags = ["security", "prod", "critical", "monitoring", "audit"]  # Duplicates removed
   #   }
   # }
 }

--- a/internal/provider/mergo_function.go
+++ b/internal/provider/mergo_function.go
@@ -180,26 +180,32 @@ func deepMergeMaps(dst, src reflect.Value, appendSlice bool, uniqueSlice bool, n
 }
 
 func unionSlices(dst, src reflect.Value) reflect.Value {
-	seen := make(map[any]bool)
 	result := reflect.MakeSlice(dst.Type(), 0, dst.Len()+src.Len())
 
 	// Add elements from dst (preserving order)
 	for i := 0; i < dst.Len(); i++ {
-		elem := dst.Index(i).Interface()
-		if !seen[elem] {
-			seen[elem] = true
+		if !containsElement(result, dst.Index(i)) {
 			result = reflect.Append(result, dst.Index(i))
 		}
 	}
 
 	// Add new elements from src
 	for i := 0; i < src.Len(); i++ {
-		elem := src.Index(i).Interface()
-		if !seen[elem] {
-			seen[elem] = true
+		if !containsElement(result, src.Index(i)) {
 			result = reflect.Append(result, src.Index(i))
 		}
 	}
 
 	return result
+}
+
+// containsElement checks if a slice contains a specific element using reflect.DeepEqual
+func containsElement(slice, elem reflect.Value) bool {
+	elemInterface := elem.Interface()
+	for i := 0; i < slice.Len(); i++ {
+		if reflect.DeepEqual(slice.Index(i).Interface(), elemInterface) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/provider/mergo_function.go
+++ b/internal/provider/mergo_function.go
@@ -65,6 +65,7 @@ func (r MergoFunction) Run(ctx context.Context, req function.RunRequest, resp *f
 	with_override := true
 	no_null_override := false
 	with_append := false
+	with_union := false
 
 	for i, arg := range args {
 		if arg.IsNull() {
@@ -89,6 +90,9 @@ func (r MergoFunction) Run(ctx context.Context, req function.RunRequest, resp *f
 				opts = append(opts, mergo.WithAppendSlice)
 				with_append = true
 
+			case "union", "union_lists":
+				with_union = true
+
 			default:
 				resp.Error = function.NewArgumentFuncError(int64(i), "unrecognised option")
 				return
@@ -110,8 +114,12 @@ func (r MergoFunction) Run(ctx context.Context, req function.RunRequest, resp *f
 		opts = append(opts, mergo.WithOverride)
 	}
 
-	if no_null_override {
-		opts = append(opts, mergo.WithTransformers(noNullOverrideTransformer{with_append: with_append}))
+	if no_null_override || with_union {
+		opts = append(opts, mergo.WithTransformers(customTransformer{
+			with_append:        with_append,
+			with_union:         with_union,
+			with_null_override: !no_null_override,
+		}))
 	}
 
 	merged, diags := helpers.Mergo(ctx, objs, opts...)
@@ -123,21 +131,23 @@ func (r MergoFunction) Run(ctx context.Context, req function.RunRequest, resp *f
 	resp.Error = function.ConcatFuncErrors(resp.Result.Set(ctx, &merged))
 }
 
-type noNullOverrideTransformer struct {
-	with_append bool
+type customTransformer struct {
+	with_append        bool
+	with_union         bool
+	with_null_override bool
 }
 
-func (t noNullOverrideTransformer) Transformer(typ reflect.Type) func(dst, src reflect.Value) error {
+func (t customTransformer) Transformer(typ reflect.Type) func(dst, src reflect.Value) error {
 	if typ.Kind() == reflect.Map {
 		return func(dst, src reflect.Value) error {
-			deepMergeMaps(dst, src, t.with_append)
+			deepMergeMaps(dst, src, t.with_append, t.with_union, t.with_null_override)
 			return nil
 		}
 	}
 	return nil
 }
 
-func deepMergeMaps(dst, src reflect.Value, appendSlice bool) reflect.Value {
+func deepMergeMaps(dst, src reflect.Value, appendSlice bool, uniqueSlice bool, nullOverride bool) reflect.Value {
 	for _, key := range src.MapKeys() {
 		srcElem := src.MapIndex(key)
 		dstElem := dst.MapIndex(key)
@@ -153,10 +163,12 @@ func deepMergeMaps(dst, src reflect.Value, appendSlice bool) reflect.Value {
 
 		if srcElem.Kind() == reflect.Map && dstElem.Kind() == reflect.Map {
 			// recursive call
-			newValue := deepMergeMaps(dstElem, srcElem, appendSlice)
+			newValue := deepMergeMaps(dstElem, srcElem, appendSlice, uniqueSlice, nullOverride)
 			dst.SetMapIndex(key, newValue)
-		} else if !srcElem.IsValid() { // skip override of nil values
+		} else if !srcElem.IsValid() && !nullOverride { // skip override of nil values only if nullOverride is false
 			continue
+		} else if srcElem.Kind() == reflect.Slice && dstElem.Kind() == reflect.Slice && uniqueSlice { // handle union
+			dst.SetMapIndex(key, unionSlices(dstElem, srcElem))
 		} else if srcElem.Kind() == reflect.Slice && dstElem.Kind() == reflect.Slice && appendSlice { // handle append
 			dst.SetMapIndex(key, reflect.AppendSlice(dstElem, srcElem))
 		} else {
@@ -165,4 +177,29 @@ func deepMergeMaps(dst, src reflect.Value, appendSlice bool) reflect.Value {
 	}
 
 	return dst
+}
+
+func unionSlices(dst, src reflect.Value) reflect.Value {
+	seen := make(map[any]bool)
+	result := reflect.MakeSlice(dst.Type(), 0, dst.Len()+src.Len())
+
+	// Add elements from dst (preserving order)
+	for i := 0; i < dst.Len(); i++ {
+		elem := dst.Index(i).Interface()
+		if !seen[elem] {
+			seen[elem] = true
+			result = reflect.Append(result, dst.Index(i))
+		}
+	}
+
+	// Add new elements from src
+	for i := 0; i < src.Len(); i++ {
+		elem := src.Index(i).Interface()
+		if !seen[elem] {
+			seen[elem] = true
+			result = reflect.Append(result, src.Index(i))
+		}
+	}
+
+	return result
 }

--- a/internal/provider/mergo_function.go
+++ b/internal/provider/mergo_function.go
@@ -199,7 +199,7 @@ func unionSlices(dst, src reflect.Value) reflect.Value {
 	return result
 }
 
-// containsElement checks if a slice contains a specific element using reflect.DeepEqual
+// containsElement checks if a slice contains a specific element using reflect.DeepEqual.
 func containsElement(slice, elem reflect.Value) bool {
 	elemInterface := elem.Interface()
 	for i := 0; i < slice.Len(); i++ {

--- a/internal/provider/mergo_function.md
+++ b/internal/provider/mergo_function.md
@@ -6,12 +6,13 @@ Unlike Terraform's built-in `merge()` function which only performs shallow mergi
 
 A distinctive feature of `mergo` is its use of string arguments to control merge strategies. Simply append one or more control strings after your maps to change how the merge operates:
 
-| Mode                                 | Description                                | Use Case                              |
-| ------------------------------------ | ------------------------------------------ | ------------------------------------- |
-| `"override"` / `"replace"` (default) | Later values replace earlier ones          | Standard configuration layering       |
-| `"no_override"`                      | Earlier values are preserved               | Setting immutable defaults            |
-| `"no_null_override"`                 | Null values don't replace existing values  | Optional configuration fields         |
-| `"append"` / `"append_lists"`        | Lists are concatenated instead of replaced | Accumulating features, rules, or tags |
+| Mode                                 | Description                                | Use Case                                |
+| ------------------------------------ | ------------------------------------------ | --------------------------------------- |
+| `"override"` / `"replace"` (default) | Later values replace earlier ones          | Standard configuration layering         |
+| `"no_override"`                      | Earlier values are preserved               | Setting immutable defaults              |
+| `"no_null_override"`                 | Null values don't replace existing values  | Optional configuration fields           |
+| `"append"` / `"append_lists"`        | Lists are concatenated instead of replaced | Accumulating features, rules, or tags   |
+| `"union"` / `"union_lists"`          | Lists are merged as sets (unique elements) | Deduplicating tags, IPs, or identifiers |
 
 ### Examples by Mode
 
@@ -76,6 +77,34 @@ locals {
   #   firewall = {
   #     allowed_ports = [22, 80, 443, 8080, 9090]
   #     denied_ips    = ["192.168.1.100", "192.168.1.101", "192.168.1.102"]
+  #   }
+  # }
+}
+```
+
+#### Union Lists Mode
+
+```hcl
+locals {
+  base_tags = {
+    security = {
+      allowed_ports = [22, 80, 443]
+      tags = ["security", "prod", "critical"]
+    }
+  }
+
+  additional_tags = {
+    security = {
+      allowed_ports = [8080, 80, 9090]
+      tags = ["monitoring", "prod", "audit"]
+    }
+  }
+
+  result = provider::deepmerge::mergo(local.base_tags, local.additional_tags, "union_lists")
+  # Result: {
+  #   security = {
+  #     allowed_ports = [22, 80, 443, 8080, 9090]  # Unique elements only
+  #     tags = ["security", "prod", "critical", "monitoring", "audit"]  # Duplicates removed
   #   }
   # }
 }
@@ -209,5 +238,42 @@ locals {
     local.prod_overrides,
     "append"
   )
+}
+```
+
+### Tag Management with Union Lists
+
+```hcl
+locals {
+  # Base tags from organization standards
+  org_tags = {
+    global_tags = ["terraform", "managed", "compliance"]
+    security_tags = ["encrypted", "monitored"]
+  }
+
+  # Team-specific tags
+  team_tags = {
+    global_tags = ["backend", "api", "terraform"]  # Some overlap
+    team_tags = ["payments", "critical"]
+  }
+
+  # Environment-specific tags
+  env_tags = {
+    global_tags = ["production", "managed"]  # More overlap
+    security_tags = ["audited", "encrypted"]  # More overlap
+  }
+
+  # Merge all tags with automatic deduplication
+  final_tags = provider::deepmerge::mergo(
+    local.org_tags,
+    local.team_tags,
+    local.env_tags,
+    "union_lists"
+  )
+  # Result: {
+  #   global_tags = ["terraform", "managed", "compliance", "backend", "api", "production"]
+  #   security_tags = ["encrypted", "monitored", "audited"]
+  #   team_tags = ["payments", "critical"]
+  # }
 }
 ```

--- a/internal/provider/mergo_function_test.go
+++ b/internal/provider/mergo_function_test.go
@@ -915,3 +915,269 @@ func TestMergoFunction_InvalidType(t *testing.T) {
 		},
 	})
 }
+
+func TestMergoFunction_UnionLists(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.8.0"))),
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+				locals {
+					map1 = {
+						tags = ["app", "terraform", "prod"]
+						ports = [80, 443, 22]
+						features = {
+							security = ["ssl", "firewall"]
+							monitoring = ["logs", "metrics"]
+						}
+					}
+					map2 = {
+						tags = ["monitoring", "prod", "security"]
+						ports = [8080, 80, 9090]
+						features = {
+							security = ["encryption", "ssl"]
+							monitoring = ["alerts", "metrics"]
+							caching = ["redis"]
+						}
+					}
+				}
+				output "test" {
+					value = provider::deepmerge::mergo(local.map1, local.map2, "union_lists")
+				}
+				`,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownOutputValue("test",
+						knownvalue.MapExact(map[string]knownvalue.Check{
+							"tags": knownvalue.ListExact([]knownvalue.Check{
+								knownvalue.StringExact("app"),
+								knownvalue.StringExact("terraform"),
+								knownvalue.StringExact("prod"),
+								knownvalue.StringExact("monitoring"),
+								knownvalue.StringExact("security"),
+							}),
+							"ports": knownvalue.ListExact([]knownvalue.Check{
+								knownvalue.Int64Exact(80),
+								knownvalue.Int64Exact(443),
+								knownvalue.Int64Exact(22),
+								knownvalue.Int64Exact(8080),
+								knownvalue.Int64Exact(9090),
+							}),
+							"features": knownvalue.MapExact(map[string]knownvalue.Check{
+								"security": knownvalue.ListExact([]knownvalue.Check{
+									knownvalue.StringExact("ssl"),
+									knownvalue.StringExact("firewall"),
+									knownvalue.StringExact("encryption"),
+								}),
+								"monitoring": knownvalue.ListExact([]knownvalue.Check{
+									knownvalue.StringExact("logs"),
+									knownvalue.StringExact("metrics"),
+									knownvalue.StringExact("alerts"),
+								}),
+								"caching": knownvalue.ListExact([]knownvalue.Check{
+									knownvalue.StringExact("redis"),
+								}),
+							}),
+						}),
+					),
+				},
+			},
+			{
+				Config: `
+				locals {
+					base = {
+						allowed_cidrs = ["10.0.0.0/8", "192.168.1.0/24"]
+						environments = ["dev", "staging"]
+					}
+					overrides = {
+						allowed_cidrs = ["172.16.0.0/12", "10.0.0.0/8"]
+						environments = ["prod", "staging"]
+					}
+				}
+				output "test" {
+					value = provider::deepmerge::mergo(local.base, local.overrides, "union_lists")
+				}
+				`,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownOutputValue("test",
+						knownvalue.MapExact(map[string]knownvalue.Check{
+							"allowed_cidrs": knownvalue.ListExact([]knownvalue.Check{
+								knownvalue.StringExact("10.0.0.0/8"),
+								knownvalue.StringExact("192.168.1.0/24"),
+								knownvalue.StringExact("172.16.0.0/12"),
+							}),
+							"environments": knownvalue.ListExact([]knownvalue.Check{
+								knownvalue.StringExact("dev"),
+								knownvalue.StringExact("staging"),
+								knownvalue.StringExact("prod"),
+							}),
+						}),
+					),
+				},
+			},
+			{
+				Config: `
+				locals {
+					map1 = {
+						mixed_types = [1, "string", true]
+						numbers = [1, 2, 3]
+					}
+					map2 = {
+						mixed_types = [true, "another", 1]
+						numbers = [3, 4, 5]
+					}
+				}
+				output "test" {
+					value = provider::deepmerge::mergo(local.map1, local.map2, "union_lists")
+				}
+				`,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownOutputValue("test",
+						knownvalue.MapExact(map[string]knownvalue.Check{
+							"mixed_types": knownvalue.ListExact([]knownvalue.Check{
+								knownvalue.Int64Exact(1),
+								knownvalue.StringExact("string"),
+								knownvalue.Bool(true),
+								knownvalue.StringExact("another"),
+							}),
+							"numbers": knownvalue.ListExact([]knownvalue.Check{
+								knownvalue.Int64Exact(1),
+								knownvalue.Int64Exact(2),
+								knownvalue.Int64Exact(3),
+								knownvalue.Int64Exact(4),
+								knownvalue.Int64Exact(5),
+							}),
+						}),
+					),
+				},
+			},
+		},
+	})
+}
+
+func TestMergoFunction_UnionListsWithNullOverride(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.8.0"))),
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+				locals {
+					base = {
+						tags = ["app", "base"]
+						important_setting = "keep_this"
+					}
+					overrides = {
+						tags = ["override", "app"]
+						important_setting = null
+						new_field = "added"
+					}
+				}
+				output "test" {
+					value = provider::deepmerge::mergo(local.base, local.overrides, "union_lists", "no_null_override")
+				}
+				`,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownOutputValue("test",
+						knownvalue.MapExact(map[string]knownvalue.Check{
+							"tags": knownvalue.ListExact([]knownvalue.Check{
+								knownvalue.StringExact("app"),
+								knownvalue.StringExact("base"),
+								knownvalue.StringExact("override"),
+							}),
+							"important_setting": knownvalue.StringExact("keep_this"),
+							"new_field":         knownvalue.StringExact("added"),
+						}),
+					),
+				},
+			},
+		},
+	})
+}
+
+func TestMergoFunction_UnionListsWithDefaultNullBehavior(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.8.0"))),
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+				locals {
+					base = {
+						tags = ["app", "base"]
+						important_setting = "replace_this"
+					}
+					overrides = {
+						tags = ["override", "app"]
+						important_setting = null
+						new_field = "added"
+					}
+				}
+				output "test" {
+					value = provider::deepmerge::mergo(local.base, local.overrides, "union_lists")
+				}
+				`,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownOutputValue("test",
+						knownvalue.MapExact(map[string]knownvalue.Check{
+							"tags": knownvalue.ListExact([]knownvalue.Check{
+								knownvalue.StringExact("app"),
+								knownvalue.StringExact("base"),
+								knownvalue.StringExact("override"),
+							}),
+							"new_field": knownvalue.StringExact("added"),
+						}),
+					),
+				},
+			},
+		},
+	})
+}
+
+func TestMergoFunction_Union_NoNullOverride(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.8.0"))),
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+				locals {
+					base = {
+						tags = ["app", "base"]
+						important_setting = "keep_this"
+					}
+					overrides = {
+						tags = ["override", "app"]
+						important_setting = null
+						new_field = "added"
+					}
+				}
+				output "test" {
+					value = provider::deepmerge::mergo(local.base, local.overrides, "union", "no_null_override")
+				}
+				`,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownOutputValue("test",
+						knownvalue.MapExact(map[string]knownvalue.Check{
+							"tags": knownvalue.ListExact([]knownvalue.Check{
+								knownvalue.StringExact("app"),
+								knownvalue.StringExact("base"),
+								knownvalue.StringExact("override"),
+							}),
+							"important_setting": knownvalue.StringExact("keep_this"),
+							"new_field":         knownvalue.StringExact("added"),
+						}),
+					),
+				},
+			},
+		},
+	})
+}


### PR DESCRIPTION
This pull request introduces a new merge strategy, `"union_lists"`, to the `mergo` function, enabling the merging of lists as sets with deduplication. The changes include updates to documentation, implementation in the codebase, and comprehensive test cases to validate the new functionality.

### Documentation Updates:
* Added `"union"` / `"union_lists"` mode to the merge strategy table in `README.md`, `docs/functions/mergo.md`, and `internal/provider/mergo_function.md`. This mode merges lists as sets, ensuring unique elements. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R56) [[2]](diffhunk://#diff-273846fc2001a7eced96c31f8bb66b584969dd44239d3c8bddc90ec3d3559833L20-R25) [[3]](diffhunk://#diff-e3a1a86bbb1ed6e145a8d9fa8324afea2264084001b289e02adfe5eb046f6b73L10-R15)
* Provided examples for `"union_lists"` mode, including practical use cases such as tag management and environment-specific configurations. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R126-R153) [[2]](diffhunk://#diff-273846fc2001a7eced96c31f8bb66b584969dd44239d3c8bddc90ec3d3559833R95-R122) [[3]](diffhunk://#diff-273846fc2001a7eced96c31f8bb66b584969dd44239d3c8bddc90ec3d3559833R254-R290) [[4]](diffhunk://#diff-e3a1a86bbb1ed6e145a8d9fa8324afea2264084001b289e02adfe5eb046f6b73R85-R112) [[5]](diffhunk://#diff-e3a1a86bbb1ed6e145a8d9fa8324afea2264084001b289e02adfe5eb046f6b73R243-R279)

### Codebase Enhancements:
* Implemented the `"union_lists"` strategy in `internal/provider/mergo_function.go`. This includes adding a `with_union` flag, updating the `customTransformer` type, modifying `deepMergeMaps` to handle union logic, and introducing a new `unionSlices` helper function. [[1]](diffhunk://#diff-5b5bd2cee7ccb3bb6c7339b71e0832d9b1a950bf0480afe3a7d94d6ebe238c0aR68) [[2]](diffhunk://#diff-5b5bd2cee7ccb3bb6c7339b71e0832d9b1a950bf0480afe3a7d94d6ebe238c0aR93-R95) [[3]](diffhunk://#diff-5b5bd2cee7ccb3bb6c7339b71e0832d9b1a950bf0480afe3a7d94d6ebe238c0aL113-R122) [[4]](diffhunk://#diff-5b5bd2cee7ccb3bb6c7339b71e0832d9b1a950bf0480afe3a7d94d6ebe238c0aL126-R150) [[5]](diffhunk://#diff-5b5bd2cee7ccb3bb6c7339b71e0832d9b1a950bf0480afe3a7d94d6ebe238c0aL156-R171) [[6]](diffhunk://#diff-5b5bd2cee7ccb3bb6c7339b71e0832d9b1a950bf0480afe3a7d94d6ebe238c0aR181-R205)

### Testing:
* Added extensive test cases in `internal/provider/mergo_function_test.go` to validate the `"union_lists"` functionality. Tests cover scenarios such as deduplication, handling null values, and merging lists with mixed types.